### PR TITLE
fix client logtype not working

### DIFF
--- a/src/Mirage.Core/GeneratedCode.cs
+++ b/src/Mirage.Core/GeneratedCode.cs
@@ -6,7 +6,7 @@ namespace Mirage
 {
     public static class GeneratedCode
     {
-        private static readonly ILogger logger = LogFactory.GetLogger(typeof(MirageClient));
+        private static readonly ILogger logger = LogFactory.GetLogger(typeof(MirageClient), LogType.Log);
 
         public const string GENERATED_NAMEPACE = "Mirage";
         public const string GENERATED_CLASS = "GeneratedNetworkCode";


### PR DESCRIPTION
Not sure if this is the correct way to fix this but it does make the client LogType.Log work as expected. Forcing a class type update in client before the first log event also works but that seemed wrong.
